### PR TITLE
feat: add AI agent interface

### DIFF
--- a/cmd/kommon/main.go
+++ b/cmd/kommon/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/takutakahashi/kommon/pkg/agent"
+	"github.com/takutakahashi/kommon/pkg/client"
+)
+
+func main() {
+	// コマンドライン引数の解析
+	var (
+		model   = flag.String("model", "gpt-4", "AI model to use")
+		apiKey  = flag.String("api-key", os.Getenv("KOMMON_API_KEY"), "API key for the AI service")
+		baseURL = flag.String("base-url", "", "Base URL for the AI service")
+		dataDir = flag.String("data-dir", getDefaultDataDir(), "Directory for storing session and history data")
+	)
+	flag.Parse()
+
+	// 必須パラメータのチェック
+	if *apiKey == "" {
+		log.Fatal("API key is required. Set it via -api-key flag or KOMMON_API_KEY environment variable")
+	}
+
+	// AgentOptionsの設定
+	opts := agent.AgentOptions{
+		Model:   *model,
+		APIKey:  *apiKey,
+		BaseURL: *baseURL,
+	}
+
+	// ClientHelperの初期化
+	ctx := context.Background()
+	helper, err := client.NewClientHelper(ctx, opts, *dataDir)
+	if err != nil {
+		log.Fatalf("Failed to create client helper: %v", err)
+	}
+	defer helper.Cleanup()
+
+	// セッションの初期化
+	if err := helper.InitializeSession(); err != nil {
+		log.Fatalf("Failed to initialize session: %v", err)
+	}
+
+	// 入力の処理
+	input := flag.Arg(0)
+	if input == "" {
+		if history, err := helper.GetHistory(); err == nil && history != "" {
+			fmt.Println("Previous interactions:")
+			fmt.Println(history)
+		}
+		fmt.Println("Please provide input as a command line argument")
+		return
+	}
+
+	// コマンドの実行
+	output, err := helper.Execute(input)
+	if err != nil {
+		log.Fatalf("Failed to execute command: %v", err)
+	}
+
+	// 結果の表示と履歴の保存
+	fmt.Println(output)
+	if err := helper.SaveHistory(input, output); err != nil {
+		log.Printf("Warning: Failed to save history: %v", err)
+	}
+}
+
+func getDefaultDataDir() string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ".kommon"
+	}
+	return filepath.Join(homeDir, ".kommon")
+}

--- a/pkg/agent/base.go
+++ b/pkg/agent/base.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+)
+
+// BaseAgent provides a basic implementation of the Agent interface
+type BaseAgent struct {
+	sessionID string
+	options   AgentOptions
+}
+
+// NewBaseAgent creates a new instance of BaseAgent
+func NewBaseAgent(opts AgentOptions) (Agent, error) {
+	if opts.Model == "" {
+		return nil, fmt.Errorf("model is required")
+	}
+	if opts.APIKey == "" {
+		return nil, fmt.Errorf("API key is required")
+	}
+	return &BaseAgent{
+		options: opts,
+	}, nil
+}
+
+// StartSession implements Agent.StartSession
+func (a *BaseAgent) StartSession(ctx context.Context) (string, error) {
+	// Initialize a new session
+	// Generate a unique session ID
+	sessionID := generateUniqueID()
+	a.sessionID = sessionID
+	return sessionID, nil
+}
+
+// Resume implements Agent.Resume
+func (a *BaseAgent) Resume(ctx context.Context, sessionID string) error {
+	// Validate and restore the session
+	if sessionID == "" {
+		return fmt.Errorf("session ID is required")
+	}
+	// Here you would typically validate the session ID and restore the session state
+	a.sessionID = sessionID
+	return nil
+}
+
+// Execute implements Agent.Execute
+func (a *BaseAgent) Execute(ctx context.Context, input string) (string, error) {
+	if a.sessionID == "" {
+		return "", fmt.Errorf("no active session")
+	}
+	if input == "" {
+		return "", fmt.Errorf("input is required")
+	}
+	// Here you would implement the actual execution logic
+	// This might involve calling an AI API, processing the input, etc.
+	return fmt.Sprintf("Processed input: %s", input), nil
+}
+
+// generateUniqueID generates a unique session ID
+// This is a placeholder implementation
+func generateUniqueID() string {
+	// Implement proper unique ID generation
+	// Could use UUID or other methods
+	return "session-123" // Placeholder
+}

--- a/pkg/agent/interface.go
+++ b/pkg/agent/interface.go
@@ -1,0 +1,33 @@
+package agent
+
+import (
+	"context"
+)
+
+// Agent represents the interface for AI agents
+type Agent interface {
+	// StartSession initializes a new session for the agent
+	// Returns a unique session ID and any error that occurred
+	StartSession(ctx context.Context) (string, error)
+
+	// Resume restores a previous session using the provided session ID
+	// Returns error if the session cannot be resumed
+	Resume(ctx context.Context, sessionID string) error
+
+	// Execute performs the specified action within the current session
+	// Returns the result of the execution and any error that occurred
+	Execute(ctx context.Context, input string) (string, error)
+}
+
+// AgentOptions contains configuration options for creating a new agent
+type AgentOptions struct {
+	// Add any necessary configuration options here
+	Model     string            // AI model to use
+	BaseURL   string           // Base URL for API endpoint
+	APIKey    string           // API key for authentication
+	Headers   map[string]string // Additional headers
+	MaxTokens int              // Maximum tokens for response
+}
+
+// NewAgent creates a new instance of an AI agent with the specified options
+type NewAgentFunc func(opts AgentOptions) (Agent, error)

--- a/pkg/client/helper.go
+++ b/pkg/client/helper.go
@@ -1,0 +1,109 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/takutakahashi/kommon/pkg/agent"
+)
+
+// ClientHelper provides helper functions for CLI client operations
+type ClientHelper struct {
+	agent    agent.Agent
+	session  string
+	dataDir  string
+	ctx      context.Context
+}
+
+// NewClientHelper creates a new instance of ClientHelper
+func NewClientHelper(ctx context.Context, opts agent.AgentOptions, dataDir string) (*ClientHelper, error) {
+	// Create agent instance
+	a, err := agent.NewBaseAgent(opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create agent: %w", err)
+	}
+
+	// Create data directory if it doesn't exist
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create data directory: %w", err)
+	}
+
+	return &ClientHelper{
+		agent:   a,
+		dataDir: dataDir,
+		ctx:     ctx,
+	}, nil
+}
+
+// InitializeSession starts a new session or resumes an existing one
+func (c *ClientHelper) InitializeSession() error {
+	// Try to load existing session
+	sessionFile := fmt.Sprintf("%s/session.txt", c.dataDir)
+	if data, err := os.ReadFile(sessionFile); err == nil && len(data) > 0 {
+		sessionID := strings.TrimSpace(string(data))
+		if err := c.agent.Resume(c.ctx, sessionID); err == nil {
+			c.session = sessionID
+			return nil
+		}
+	}
+
+	// Start new session if loading failed
+	sessionID, err := c.agent.StartSession(c.ctx)
+	if err != nil {
+		return fmt.Errorf("failed to start session: %w", err)
+	}
+
+	// Save session ID
+	if err := os.WriteFile(sessionFile, []byte(sessionID), 0644); err != nil {
+		return fmt.Errorf("failed to save session ID: %w", err)
+	}
+
+	c.session = sessionID
+	return nil
+}
+
+// Execute runs a command through the agent
+func (c *ClientHelper) Execute(input string) (string, error) {
+	if c.session == "" {
+		return "", fmt.Errorf("no active session")
+	}
+	return c.agent.Execute(c.ctx, input)
+}
+
+// SaveHistory saves command history to a file
+func (c *ClientHelper) SaveHistory(input, output string) error {
+	historyFile := fmt.Sprintf("%s/history.txt", c.dataDir)
+	entry := fmt.Sprintf("Input: %s\nOutput: %s\n---\n", input, output)
+	
+	f, err := os.OpenFile(historyFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to open history file: %w", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(entry); err != nil {
+		return fmt.Errorf("failed to write history: %w", err)
+	}
+	return nil
+}
+
+// GetHistory retrieves command history
+func (c *ClientHelper) GetHistory() (string, error) {
+	historyFile := fmt.Sprintf("%s/history.txt", c.dataDir)
+	data, err := os.ReadFile(historyFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to read history: %w", err)
+	}
+	return string(data), nil
+}
+
+// Cleanup performs cleanup operations
+func (c *ClientHelper) Cleanup() error {
+	// Add any cleanup operations here
+	return nil
+}


### PR DESCRIPTION
## 概要
AIエージェントの基本インターフェースと実装を追加します。

### 追加した機能
- Agent インターフェース
  - StartSession: 新しいセッションを開始
  - Resume: 既存のセッションを再開
  - Execute: コマンドを実行
- AgentOptions による設定管理
- BaseAgent による基本実装
  - エラーハンドリング
  - セッション管理

### 使用例


### 今後の拡張性
- 各種AIプロバイダー向けの具体的な実装の追加が可能
- セッション永続化機能の追加
- 高度なエラーハンドリングの実装