### PR TITLE
feat: implement goose agent

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Push Docker Images
 
 on:
   push:
@@ -12,7 +12,8 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/takutakahashi/kommon-agent
+  BASE_IMAGE_NAME: ghcr.io/takutakahashi/kommon
+  GOOSE_IMAGE_NAME: ghcr.io/takutakahashi/kommon-goose
 
 jobs:
   build-and-push:
@@ -20,6 +21,13 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - image: ${{ env.BASE_IMAGE_NAME }}
+            dockerfile: Dockerfile
+          - image: ${{ env.GOOSE_IMAGE_NAME }}
+            dockerfile: Dockerfile.goose
 
     steps:
       - name: Checkout repository
@@ -40,7 +48,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ matrix.image }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -53,6 +61,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,7 @@ on:
 env:
   REGISTRY: ghcr.io
   BASE_IMAGE_NAME: ghcr.io/takutakahashi/kommon
-  GOOSE_IMAGE_NAME: ghcr.io/takutakahashi/kommon-goose
+  GOOSE_IMAGE_NAME: ghcr.io/takutakahashi/kommon-goose-agent
 
 jobs:
   build-and-push:

--- a/Dockerfile.goose
+++ b/Dockerfile.goose
@@ -1,10 +1,3 @@
-FROM golang:1.20-alpine AS builder
-
-WORKDIR /app
-COPY . .
-RUN go mod download
-RUN CGO_ENABLED=0 GOOS=linux go build -o kommon
-
 FROM debian:bookworm-slim
 
 # Install system dependencies
@@ -18,9 +11,6 @@ RUN apt-get update && apt-get install -y \
 
 # Set working directory
 WORKDIR /root
-
-# Copy kommon binary from builder
-COPY --from=builder /app/kommon .
 
 # Download and install Goose binary
 RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh -o install.sh \
@@ -37,4 +27,5 @@ RUN mkdir -p /root/.config/goose
 # Verify installation
 RUN goose --version
 
-ENTRYPOINT ["./kommon"]
+ENTRYPOINT ["goose"]
+CMD ["session"]

--- a/Dockerfile.goose
+++ b/Dockerfile.goose
@@ -1,0 +1,40 @@
+FROM golang:1.20-alpine AS builder
+
+WORKDIR /app
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -o kommon
+
+FROM debian:bookworm-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
+    bzip2 \
+    libxcb1 \
+    libdbus-1-3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /root
+
+# Copy kommon binary from builder
+COPY --from=builder /app/kommon .
+
+# Download and install Goose binary
+RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh -o install.sh \
+    && chmod +x install.sh \
+    && ./install.sh \
+    && rm install.sh
+
+# Add the local bin directory to PATH
+ENV PATH="/root/.local/bin:${PATH}"
+
+# Create necessary directories for Goose
+RUN mkdir -p /root/.config/goose
+
+# Verify installation
+RUN goose --version
+
+ENTRYPOINT ["./kommon"]

--- a/Dockerfile.goose
+++ b/Dockerfile.goose
@@ -1,3 +1,10 @@
+FROM golang:1.20-alpine AS builder
+
+WORKDIR /app
+COPY . .
+RUN go mod download
+RUN CGO_ENABLED=0 GOOS=linux go build -o kommon
+
 FROM debian:bookworm-slim
 
 # Install system dependencies
@@ -11,6 +18,9 @@ RUN apt-get update && apt-get install -y \
 
 # Set working directory
 WORKDIR /root
+
+# Copy kommon binary from builder
+COPY --from=builder /app/kommon /usr/local/bin/
 
 # Download and install Goose binary
 RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh -o install.sh \
@@ -27,5 +37,4 @@ RUN mkdir -p /root/.config/goose
 # Verify installation
 RUN goose --version
 
-ENTRYPOINT ["goose"]
-CMD ["session"]
+ENTRYPOINT ["kommon"]


### PR DESCRIPTION
This PR implements the following changes:

## Main Features
- Implement Goose agent client integration
- Split Docker images into base and Goose-enabled versions
- Update CI to build and push both images

## Technical Changes
- Migrate CLI to use cobra and viper for better command handling
- Implement Goose agent client with proper session management
- Separate Docker builds:
  - Base image: ghcr.io/takutakahashi/kommon
  - Goose image: ghcr.io/takutakahashi/kommon-goose
- Remove history feature for simplification

## Testing Instructions
1. Build and run the base image:
```bash
docker build -t kommon .
```

2. Build and run the Goose image:
```bash
docker build -f Dockerfile.goose -t kommon-goose .
```

3. Test Goose agent:
```bash
kommon run --agent goose --session-id test "Your prompt here"
```

## Notes
- The Goose image includes both kommon and Goose CLI
- CI will automatically build and push both images on merge