### PR TITLE
feat: add issue label event handler

### DIFF
--- a/pkg/github/handler.go
+++ b/pkg/github/handler.go
@@ -3,53 +3,103 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v57/github"
 	"github.com/sirupsen/logrus"
 )
 
-// LabelHandler handles GitHub issue label events
-type LabelHandler struct {
-	client *github.Client
-	log    *logrus.Logger
+// Handler handles GitHub issue events
+type Handler struct {
+	client   *github.Client
+	log      *logrus.Logger
+	appLogin string // GitHub Appのログイン名
 }
 
-// NewLabelHandler creates a new LabelHandler instance
-func NewLabelHandler(client *github.Client, log *logrus.Logger) *LabelHandler {
-	return &LabelHandler{
-		client: client,
-		log:    log,
+// NewHandler creates a new Handler instance
+func NewHandler(client *github.Client, log *logrus.Logger, appLogin string) *Handler {
+	return &Handler{
+		client:   client,
+		log:      log,
+		appLogin: appLogin,
 	}
 }
 
 // HandleIssuesEvent processes GitHub issue events
-func (h *LabelHandler) HandleIssuesEvent(ctx context.Context, event *github.IssuesEvent) error {
-	if event.GetAction() != "labeled" {
-		return nil
-	}
-
+func (h *Handler) HandleIssuesEvent(ctx context.Context, event *github.IssuesEvent) error {
 	issue := event.GetIssue()
-	label := event.GetLabel()
 	repo := event.GetRepo()
 
-	h.log.WithFields(logrus.Fields{
-		"issue_number": issue.GetNumber(),
-		"label":        label.GetName(),
-		"repo":         repo.GetFullName(),
-	}).Info("Issue labeled")
+	// ラベルイベントの処理
+	if event.GetAction() == "labeled" {
+		label := event.GetLabel()
+		h.log.WithFields(logrus.Fields{
+			"issue_number": issue.GetNumber(),
+			"label":        label.GetName(),
+			"repo":         repo.GetFullName(),
+		}).Info("Issue labeled")
 
-	// カスタムロジックを追加
-	switch label.GetName() {
-	case "needs-review":
-		return h.handleNeedsReview(ctx, repo, issue)
-	case "bug":
-		return h.handleBugLabel(ctx, repo, issue)
+		switch label.GetName() {
+		case "needs-review":
+			return h.handleNeedsReview(ctx, repo, issue)
+		case "bug":
+			return h.handleBugLabel(ctx, repo, issue)
+		}
+	}
+
+	// メンションの処理
+	if event.GetAction() == "opened" || event.GetAction() == "edited" {
+		return h.handleMention(ctx, repo, issue)
 	}
 
 	return nil
 }
 
-func (h *LabelHandler) handleNeedsReview(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
+// handleMention processes mentions of the GitHub App in issues
+func (h *Handler) handleMention(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
+	body := issue.GetBody()
+	if body == "" {
+		return nil
+	}
+
+	// @アプリ名 のメンションを確認
+	mention := fmt.Sprintf("@%s", h.appLogin)
+	if !strings.Contains(body, mention) {
+		return nil
+	}
+
+	h.log.WithFields(logrus.Fields{
+		"issue_number": issue.GetNumber(),
+		"repo":        repo.GetFullName(),
+		"body":        body,
+	}).Info("App mentioned in issue")
+
+	// メンションへの応答
+	comment := &github.IssueComment{
+		Body: github.String(fmt.Sprintf("こんにちは！ @%s です。\nメンションありがとうございます。\n\n"+
+			"以下のコマンドが利用可能です:\n"+
+			"- `help` - 利用可能なコマンドの一覧を表示\n"+
+			"- `status` - 現在の状態を確認\n"+
+			"- `assign` - 担当者の割り当て\n\n"+
+			"コマンドを使用する場合は、`@%s command` の形式で指定してください。", 
+			h.appLogin, h.appLogin)),
+	}
+
+	_, _, err := h.client.Issues.CreateComment(
+		ctx,
+		repo.GetOwner().GetLogin(),
+		repo.GetName(),
+		issue.GetNumber(),
+		comment,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create comment: %v", err)
+	}
+
+	return nil
+}
+
+func (h *Handler) handleNeedsReview(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
 	comment := &github.IssueComment{
 		Body: github.String("このIssueはレビューが必要とマークされました。チームメンバーが確認します。"),
 	}
@@ -68,7 +118,7 @@ func (h *LabelHandler) handleNeedsReview(ctx context.Context, repo *github.Repos
 	return nil
 }
 
-func (h *LabelHandler) handleBugLabel(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
+func (h *Handler) handleBugLabel(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
 	comment := &github.IssueComment{
 		Body: github.String("このIssueはバグとしてマークされました。調査と優先度付けを行います。"),
 	}

--- a/pkg/github/handler.go
+++ b/pkg/github/handler.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/sirupsen/logrus"
+)
+
+// LabelHandler handles GitHub issue label events
+type LabelHandler struct {
+	client *github.Client
+	log    *logrus.Logger
+}
+
+// NewLabelHandler creates a new LabelHandler instance
+func NewLabelHandler(client *github.Client, log *logrus.Logger) *LabelHandler {
+	return &LabelHandler{
+		client: client,
+		log:    log,
+	}
+}
+
+// HandleIssuesEvent processes GitHub issue events
+func (h *LabelHandler) HandleIssuesEvent(ctx context.Context, event *github.IssuesEvent) error {
+	if event.GetAction() != "labeled" {
+		return nil
+	}
+
+	issue := event.GetIssue()
+	label := event.GetLabel()
+	repo := event.GetRepo()
+
+	h.log.WithFields(logrus.Fields{
+		"issue_number": issue.GetNumber(),
+		"label":        label.GetName(),
+		"repo":         repo.GetFullName(),
+	}).Info("Issue labeled")
+
+	// カスタムロジックを追加
+	switch label.GetName() {
+	case "needs-review":
+		return h.handleNeedsReview(ctx, repo, issue)
+	case "bug":
+		return h.handleBugLabel(ctx, repo, issue)
+	}
+
+	return nil
+}
+
+func (h *LabelHandler) handleNeedsReview(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
+	comment := &github.IssueComment{
+		Body: github.String("このIssueはレビューが必要とマークされました。チームメンバーが確認します。"),
+	}
+	
+	_, _, err := h.client.Issues.CreateComment(
+		ctx,
+		repo.GetOwner().GetLogin(),
+		repo.GetName(),
+		issue.GetNumber(),
+		comment,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create comment: %v", err)
+	}
+	
+	return nil
+}
+
+func (h *LabelHandler) handleBugLabel(ctx context.Context, repo *github.Repository, issue *github.Issue) error {
+	comment := &github.IssueComment{
+		Body: github.String("このIssueはバグとしてマークされました。調査と優先度付けを行います。"),
+	}
+	
+	_, _, err := h.client.Issues.CreateComment(
+		ctx,
+		repo.GetOwner().GetLogin(),
+		repo.GetName(),
+		issue.GetNumber(),
+		comment,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create comment: %v", err)
+	}
+	
+	return nil
+}


### PR DESCRIPTION
# 概要
GitHub Issueのラベルイベントを処理する機能を追加しました。

## 機能
1. Issue labelイベントの処理機能を追加
2. 特定のラベル(needs-review, bug)に対する自動コメント機能
3. エラーハンドリングとロギング

## 主な変更点
- : ラベルイベント処理用の新規ハンドラを追加
- : WebhookサーバーにIssueイベント処理を追加

## テスト
- [ ] Issue作成時のラベル付与
- [ ] 特定ラベル付与時の自動コメント