### PR TITLE
refactor: Move github-related code into packages

### DIFF
--- a/cmd/github.go
+++ b/cmd/github.go
@@ -2,24 +2,16 @@ package cmd
 
 import (
 	"context"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
-	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
-	"github.com/google/go-github/v57/github"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/takutakahashi/kommon/pkg/agent"
+	"github.com/takutakahashi/kommon/pkg/config"
+	"github.com/takutakahashi/kommon/pkg/github/server"
 )
 
 var (
@@ -63,349 +55,13 @@ func init() {
 	viper.SetDefault("github.app_id", 0)
 	viper.SetDefault("github.private_key_file", "")
 	viper.SetDefault("github.webhook_secret", "")
-}
 
-func init() {
 	rootCmd.AddCommand(githubCmd)
-	if cfgFile != "" {
-		viper.SetConfigFile(cfgFile)
-	} else {
-		home, err := os.UserHomeDir()
-		cobra.CheckErr(err)
-
-		viper.AddConfigPath(home)
-		viper.SetConfigType("yaml")
-		viper.SetConfigName(".kommon")
-	}
-
-	viper.AutomaticEnv()
-	viper.SetEnvPrefix("KOMMON")
-
-	if err := viper.ReadInConfig(); err == nil {
-		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
-	}
-}
-
-type WebhookServer struct {
-	log           *logrus.Logger
-	server        *http.Server
-	appID         int64
-	privateKey    *rsa.PrivateKey
-	webhookSecret string
-	appSlug       string // GitHub App のスラグ名（@mention で使用される名前）
-	agents        map[string]agent.Agent
-}
-
-type Config struct {
-	Port            string
-	WebhookSecret   string
-	AppID           int64
-	PrivateKeyFile  string
-	ShutdownTimeout time.Duration
-}
-
-// generateJWT generates a JWT for GitHub App authentication
-func (ws *WebhookServer) generateJWT() (string, error) {
-	now := time.Now()
-	claims := jwt.RegisteredClaims{
-		IssuedAt:  jwt.NewNumericDate(now),
-		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
-		Issuer:    strconv.FormatInt(ws.appID, 10),
-	}
-
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
-	return token.SignedString(ws.privateKey)
-}
-
-// getInstallationClient creates a new GitHub client for a specific installation
-func (ws *WebhookServer) getInstallationClient(ctx context.Context, installationID int64) (*github.Client, error) {
-	jwt, err := ws.generateJWT()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate JWT: %v", err)
-	}
-
-	// Create a temporary client using the JWT
-	jwtClient := github.NewTokenClient(ctx, jwt)
-
-	// Get an installation token
-	token, _, err := jwtClient.Apps.CreateInstallationToken(
-		ctx,
-		installationID,
-		&github.InstallationTokenOptions{},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create installation token: %v", err)
-	}
-
-	// Create a new client using the installation token
-	return github.NewTokenClient(ctx, token.GetToken()), nil
-}
-
-func NewWebhookServer(cfg Config) (*WebhookServer, error) {
-	log := logrus.New()
-	log.SetFormatter(&logrus.JSONFormatter{})
-
-	// Read private key
-	privateKeyBytes, err := os.ReadFile(cfg.PrivateKeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read private key file: %v", err)
-	}
-
-	block, _ := pem.Decode(privateKeyBytes)
-	if block == nil {
-		return nil, fmt.Errorf("failed to decode PEM block")
-	}
-
-	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key: %v", err)
-	}
-
-	ws := &WebhookServer{
-		log:           log,
-		appID:         cfg.AppID,
-		privateKey:    privateKey,
-		webhookSecret: cfg.WebhookSecret,
-		server: &http.Server{
-			Addr:              ":" + cfg.Port,
-			Handler:           nil, // 後で設定
-			ReadHeaderTimeout: 10 * time.Second,
-		},
-		agents: make(map[string]agent.Agent),
-	}
-
-	// GitHub App の情報を取得
-	jwt, err := ws.generateJWT()
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate JWT: %v", err)
-	}
-
-	ctx := context.Background()
-	client := github.NewTokenClient(ctx, jwt)
-	app, _, err := client.Apps.Get(ctx, "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get app information: %v", err)
-	}
-	ws.appSlug = app.GetSlug()
-	log.Infof("GitHub App name (@%s) retrieved successfully", ws.appSlug)
-
-	// Create mux and set handlers
-	mux := http.NewServeMux()
-	mux.HandleFunc("/webhook", ws.handleWebhook)
-	ws.server.Handler = mux
-
-	return ws, nil
-}
-
-func (ws *WebhookServer) Start() error {
-	done := make(chan bool)
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		<-quit
-		ws.log.Info("Server is shutting down...")
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		if err := ws.server.Shutdown(ctx); err != nil {
-			ws.log.Fatalf("Could not gracefully shutdown the server: %v\n", err)
-		}
-		close(done)
-	}()
-
-	ws.log.Infof("Server is starting on port%s", ws.server.Addr)
-	if err := ws.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		return fmt.Errorf("could not listen on %s: %v", ws.server.Addr, err)
-	}
-
-	<-done
-	ws.log.Info("Server stopped")
-	return nil
-}
-
-func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-
-	payload, err := github.ValidatePayload(r, []byte(ws.webhookSecret))
-	if err != nil {
-		ws.log.Errorf("Error validating webhook payload: %v", err)
-		http.Error(w, "Invalid payload", http.StatusBadRequest)
-		return
-	}
-
-	event, err := github.ParseWebHook(github.WebHookType(r), payload)
-	if err != nil {
-		ws.log.Errorf("Error parsing webhook: %v", err)
-		http.Error(w, "Error parsing webhook", http.StatusBadRequest)
-		return
-	}
-
-	// Get installation ID from the event
-	var installationID int64
-	switch e := event.(type) {
-	case *github.PushEvent:
-		installationID = e.GetInstallation().GetID()
-		ws.handlePushEvent(r.Context(), e, installationID)
-	case *github.PullRequestEvent:
-		installationID = e.GetInstallation().GetID()
-		ws.handlePullRequestEvent(r.Context(), e, installationID)
-	case *github.IssueCommentEvent:
-		installationID = e.GetInstallation().GetID()
-		ws.handleIssueCommentEvent(r.Context(), e, installationID)
-	default:
-		ws.log.WithFields(logrus.Fields{
-			"event_type": github.WebHookType(r),
-		}).Info("Received unhandled event type")
-	}
-
-	w.WriteHeader(http.StatusOK)
-}
-
-func (ws *WebhookServer) handlePushEvent(ctx context.Context, event *github.PushEvent, installationID int64) {
-	client, err := ws.getInstallationClient(ctx, installationID)
-	if err != nil {
-		ws.log.Errorf("Failed to get installation client: %v", err)
-		return
-	}
-	ws.log.WithFields(logrus.Fields{
-		"repo":    event.GetRepo().GetFullName(),
-		"ref":     event.GetRef(),
-		"commits": len(event.Commits),
-		"pusher":  event.GetPusher().GetName(),
-	}).Info("Received push event")
-
-	// Example: Get repository details using the installation client
-	repo, _, err := client.Repositories.Get(ctx, event.GetRepo().GetOwner().GetLogin(), event.GetRepo().GetName())
-	if err != nil {
-		ws.log.Errorf("Failed to get repository details: %v", err)
-		return
-	}
-
-	ws.log.WithFields(logrus.Fields{
-		"stars":          repo.GetStargazersCount(),
-		"visibility":     repo.GetVisibility(),
-		"default_branch": repo.GetDefaultBranch(),
-	}).Info("Repository details")
-}
-
-func (ws *WebhookServer) handlePullRequestEvent(ctx context.Context, event *github.PullRequestEvent, installationID int64) {
-	client, err := ws.getInstallationClient(ctx, installationID)
-	if err != nil {
-		ws.log.Errorf("Failed to get installation client: %v", err)
-		return
-	}
-
-	ws.log.WithFields(logrus.Fields{
-		"repo":      event.GetRepo().GetFullName(),
-		"pr_number": event.GetPullRequest().GetNumber(),
-		"action":    event.GetAction(),
-		"title":     event.GetPullRequest().GetTitle(),
-	}).Info("Received pull request event")
-
-	// Example: Add a comment to the PR
-	if event.GetAction() == "opened" {
-		comment := &github.IssueComment{
-			Body: github.String("Thank you for your contribution! 🎉"),
-		}
-		_, _, err := client.Issues.CreateComment(
-			ctx,
-			event.GetRepo().GetOwner().GetLogin(),
-			event.GetRepo().GetName(),
-			event.GetPullRequest().GetNumber(),
-			comment,
-		)
-		if err != nil {
-			ws.log.Errorf("Failed to create comment: %v", err)
-		}
-	}
-}
-
-func (ws *WebhookServer) kommonCommand(text string) bool {
-
-	// メンションの確認 (@{app-slug} の形式)
-	mentionText := "@" + ws.appSlug
-
-	return strings.Contains(text, "/kommon") || strings.Contains(text, mentionText)
-}
-
-func (ws *WebhookServer) handleIssueCommentEvent(ctx context.Context, event *github.IssueCommentEvent, installationID int64) {
-	client, err := ws.getInstallationClient(ctx, installationID)
-	if err != nil {
-		ws.log.Errorf("Failed to get installation client: %v", err)
-		return
-	}
-
-	comment := event.GetComment()
-	if comment == nil {
-		return
-	}
-
-	if !ws.kommonCommand(comment.GetBody()) {
-		return
-	}
-
-	ws.log.WithFields(logrus.Fields{
-		"repo":       event.GetRepo().GetFullName(),
-		"issue":      event.GetIssue().GetNumber(),
-		"comment_id": comment.GetID(),
-		"comment_by": event.GetSender().GetLogin(),
-		"mentioned":  "@" + ws.appSlug,
-		"comment":    comment.GetBody(),
-	}).Info("Received mention in issue comment")
-
-	agent := ws.GetAgent(event.GetRepo().GetFullName(), event.GetIssue().GetNumber(), "")
-	res, err := agent.Execute(ctx, comment.GetBody())
-	if err != nil {
-		ws.log.Errorf("Failed to execute prompt: %v", err)
-		return
-	}
-	// コメントを作成
-	newComment := &github.IssueComment{
-		Body: github.String(res),
-	}
-
-	// コメントを投稿
-	_, _, err = client.Issues.CreateComment(
-		ctx,
-		event.GetRepo().GetOwner().GetLogin(),
-		event.GetRepo().GetName(),
-		event.GetIssue().GetNumber(),
-		newComment,
-	)
-	if err != nil {
-		ws.log.Errorf("コメントの投稿に失敗しました: %v", err)
-		return
-	}
-
-	ws.log.Info("Successfully responded to mention")
-}
-
-func sessionID(repoFullName string, issueNumber int) string {
-	return fmt.Sprintf("%s-%d", repoFullName, issueNumber)
-}
-
-func (ws *WebhookServer) GetAgent(repoFullName string, issueNumber int, installationToken string) agent.Agent {
-	if _, ok := ws.agents[sessionID(repoFullName, issueNumber)]; !ok {
-		ws.agents[sessionID(repoFullName, issueNumber)] = &agent.GooseAgent{
-			Opts: agent.GooseOptions{
-				SessionID:   sessionID(repoFullName, issueNumber),
-				APIType:     agent.GooseAPITypeOpenRouter,
-				APIKey:      installationToken,
-				Instruction: "You are a helpful assistant that can answer questions and help with tasks.",
-			},
-		}
-	}
-	return ws.agents[sessionID(repoFullName, issueNumber)]
 }
 
 func runServe(cmd *cobra.Command, args []string) error {
-	// First try to get values from github-specific flags
-	cfg := Config{
+	// github-specific フラグから設定を取得
+	cfg := &config.GithubConfig{
 		Port:            viper.GetString("github.port"),
 		WebhookSecret:   viper.GetString("github.webhook_secret"),
 		AppID:           viper.GetInt64("github.app_id"),
@@ -413,7 +69,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 		ShutdownTimeout: viper.GetDuration("github.shutdown_timeout"),
 	}
 
-	// If values are not set, try to get them from root-level environment variables
+	// ルートレベルの環境変数からも設定を取得
 	if cfg.WebhookSecret == "" {
 		cfg.WebhookSecret = viper.GetString("github_app_webhook_secret")
 	}
@@ -424,12 +80,29 @@ func runServe(cmd *cobra.Command, args []string) error {
 		cfg.PrivateKeyFile = viper.GetString("github_app_private_key")
 	}
 
-	server, err := NewWebhookServer(cfg)
+	webhookServer, err := server.NewWebhookServer(cfg)
 	if err != nil {
 		return fmt.Errorf("failed to create webhook server: %v", err)
 	}
 
-	return server.Start()
+	// シグナルハンドリングの設定
+	done := make(chan bool, 1)
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+	ctx := context.Background()
+	go func() {
+		<-quit
+		ctx, cancel := context.WithTimeout(ctx, cfg.ShutdownTimeout)
+		defer cancel()
+
+		if err := webhookServer.Shutdown(ctx); err != nil {
+			fmt.Printf("Could not gracefully shutdown the server: %v\n", err)
+		}
+		close(done)
+	}()
+
+	return webhookServer.Start(ctx)
 }
 
 func GetGitHubCommand() *cobra.Command {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import "time"
+
+// GithubConfig は GitHub App の設定を保持する構造体
+type GithubConfig struct {
+	Port            string
+	WebhookSecret   string
+	AppID           int64
+	PrivateKeyFile  string
+	ShutdownTimeout time.Duration
+}
+
+// NewGithubConfig は新しい GithubConfig インスタンスを作成します
+func NewGithubConfig(
+	port string,
+	webhookSecret string,
+	appID int64,
+	privateKeyFile string,
+	shutdownTimeout time.Duration,
+) *GithubConfig {
+	return &GithubConfig{
+		Port:            port,
+		WebhookSecret:   webhookSecret,
+		AppID:           appID,
+		PrivateKeyFile:  privateKeyFile,
+		ShutdownTimeout: shutdownTimeout,
+	}
+}

--- a/pkg/github/agent/manager.go
+++ b/pkg/github/agent/manager.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/takutakahashi/kommon/pkg/agent"
+)
+
+// Manager は Agent インスタンスを管理します
+type Manager struct {
+	agents map[string]agent.Agent
+	mu     sync.RWMutex
+}
+
+// NewManager は新しい Manager インスタンスを作成します
+func NewManager() *Manager {
+	return &Manager{
+		agents: make(map[string]agent.Agent),
+	}
+}
+
+// sessionID は一意のセッションIDを生成します
+func sessionID(repoFullName string, issueNumber int) string {
+	return fmt.Sprintf("%s-%d", repoFullName, issueNumber)
+}
+
+// GetAgent は Agent インスタンスを取得または作成します
+func (m *Manager) GetAgent(repoFullName string, issueNumber int, installationToken string) agent.Agent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	sID := sessionID(repoFullName, issueNumber)
+	if _, ok := m.agents[sID]; !ok {
+		m.agents[sID] = &agent.GooseAgent{
+			Opts: agent.GooseOptions{
+				SessionID:   sID,
+				APIType:     agent.GooseAPITypeOpenRouter,
+				APIKey:      installationToken,
+				Instruction: "You are a helpful assistant that can answer questions and help with tasks.",
+			},
+		}
+	}
+	return m.agents[sID]
+}
+
+// RemoveAgent は Agent インスタンスを削除します
+func (m *Manager) RemoveAgent(repoFullName string, issueNumber int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.agents, sessionID(repoFullName, issueNumber))
+}

--- a/pkg/github/auth/jwt.go
+++ b/pkg/github/auth/jwt.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/go-github/v57/github"
+)
+
+// GitHubAuth は GitHub 認証に関する機能を提供します
+type GitHubAuth struct {
+	appID      int64
+	privateKey *rsa.PrivateKey
+}
+
+// NewGitHubAuth は新しい GitHubAuth インスタンスを作成します
+func NewGitHubAuth(appID int64, privateKey *rsa.PrivateKey) *GitHubAuth {
+	return &GitHubAuth{
+		appID:      appID,
+		privateKey: privateKey,
+	}
+}
+
+// GenerateJWT は GitHub App 認証用の JWT を生成します
+func (a *GitHubAuth) GenerateJWT() (string, error) {
+	now := time.Now()
+	claims := jwt.RegisteredClaims{
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(10 * time.Minute)),
+		Issuer:    strconv.FormatInt(a.appID, 10),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	return token.SignedString(a.privateKey)
+}
+
+// GetInstallationClient は特定のインストールのための GitHub クライアントを作成します
+func (a *GitHubAuth) GetInstallationClient(ctx context.Context, installationID int64) (*github.Client, error) {
+	jwt, err := a.GenerateJWT()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate JWT: %v", err)
+	}
+
+	// JWT を使用して一時的なクライアントを作成
+	jwtClient := github.NewTokenClient(ctx, jwt)
+
+	// インストールトークンを取得
+	token, _, err := jwtClient.Apps.CreateInstallationToken(
+		ctx,
+		installationID,
+		&github.InstallationTokenOptions{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create installation token: %v", err)
+	}
+
+	// インストールトークンを使用して新しいクライアントを作成
+	return github.NewTokenClient(ctx, token.GetToken()), nil
+}

--- a/pkg/github/server/handlers.go
+++ b/pkg/github/server/handlers.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"context"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/sirupsen/logrus"
+)
+
+// handlePushEvent は push イベントを処理します
+func (ws *WebhookServer) handlePushEvent(ctx context.Context, event *github.PushEvent, installationID int64) {
+	client, err := ws.auth.GetInstallationClient(ctx, installationID)
+	if err != nil {
+		ws.log.Errorf("Failed to get installation client: %v", err)
+		return
+	}
+
+	ws.log.WithFields(logrus.Fields{
+		"repo":    event.GetRepo().GetFullName(),
+		"ref":     event.GetRef(),
+		"commits": len(event.Commits),
+		"pusher":  event.GetPusher().GetName(),
+	}).Info("Received push event")
+
+	// リポジトリ詳細の取得
+	repo, _, err := client.Repositories.Get(ctx, event.GetRepo().GetOwner().GetLogin(), event.GetRepo().GetName())
+	if err != nil {
+		ws.log.Errorf("Failed to get repository details: %v", err)
+		return
+	}
+
+	ws.log.WithFields(logrus.Fields{
+		"stars":          repo.GetStargazersCount(),
+		"visibility":     repo.GetVisibility(),
+		"default_branch": repo.GetDefaultBranch(),
+	}).Info("Repository details")
+}
+
+// handlePullRequestEvent は pull request イベントを処理します
+func (ws *WebhookServer) handlePullRequestEvent(ctx context.Context, event *github.PullRequestEvent, installationID int64) {
+	client, err := ws.auth.GetInstallationClient(ctx, installationID)
+	if err != nil {
+		ws.log.Errorf("Failed to get installation client: %v", err)
+		return
+	}
+
+	ws.log.WithFields(logrus.Fields{
+		"repo":      event.GetRepo().GetFullName(),
+		"pr_number": event.GetPullRequest().GetNumber(),
+		"action":    event.GetAction(),
+		"title":     event.GetPullRequest().GetTitle(),
+	}).Info("Received pull request event")
+
+	if event.GetAction() == "opened" {
+		comment := &github.IssueComment{
+			Body: github.String("Thank you for your contribution! 🎉"),
+		}
+		_, _, err := client.Issues.CreateComment(
+			ctx,
+			event.GetRepo().GetOwner().GetLogin(),
+			event.GetRepo().GetName(),
+			event.GetPullRequest().GetNumber(),
+			comment,
+		)
+		if err != nil {
+			ws.log.Errorf("Failed to create comment: %v", err)
+		}
+	}
+}
+
+// handleIssueCommentEvent は issue comment イベントを処理します
+func (ws *WebhookServer) handleIssueCommentEvent(ctx context.Context, event *github.IssueCommentEvent, installationID int64) {
+	client, err := ws.auth.GetInstallationClient(ctx, installationID)
+	if err != nil {
+		ws.log.Errorf("Failed to get installation client: %v", err)
+		return
+	}
+
+	comment := event.GetComment()
+	if comment == nil {
+		return
+	}
+
+	if !ws.isKommonCommand(comment.GetBody()) {
+		return
+	}
+
+	ws.log.WithFields(logrus.Fields{
+		"repo":       event.GetRepo().GetFullName(),
+		"issue":      event.GetIssue().GetNumber(),
+		"comment_id": comment.GetID(),
+		"comment_by": event.GetSender().GetLogin(),
+		"mentioned":  "@" + ws.appSlug,
+		"comment":    comment.GetBody(),
+	}).Info("Received mention in issue comment")
+
+	agent := ws.agentManager.GetAgent(event.GetRepo().GetFullName(), event.GetIssue().GetNumber(), "")
+	res, err := agent.Execute(ctx, comment.GetBody())
+	if err != nil {
+		ws.log.Errorf("Failed to execute prompt: %v", err)
+		return
+	}
+
+	newComment := &github.IssueComment{
+		Body: github.String(res),
+	}
+
+	_, _, err = client.Issues.CreateComment(
+		ctx,
+		event.GetRepo().GetOwner().GetLogin(),
+		event.GetRepo().GetName(),
+		event.GetIssue().GetNumber(),
+		newComment,
+	)
+	if err != nil {
+		ws.log.Errorf("Failed to post comment: %v", err)
+		return
+	}
+
+	ws.log.Info("Successfully responded to mention")
+}

--- a/pkg/github/server/server.go
+++ b/pkg/github/server/server.go
@@ -1,0 +1,149 @@
+package server
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v57/github"
+	"github.com/sirupsen/logrus"
+	"github.com/takutakahashi/kommon/pkg/config"
+	"github.com/takutakahashi/kommon/pkg/github/agent"
+	"github.com/takutakahashi/kommon/pkg/github/auth"
+)
+
+// WebhookServer は GitHub webhook サーバーを表します
+type WebhookServer struct {
+	log           *logrus.Logger
+	server        *http.Server
+	auth          *auth.GitHubAuth
+	webhookSecret string
+	appSlug       string
+	agentManager  *agent.Manager
+}
+
+// NewWebhookServer は新しい WebhookServer インスタンスを作成します
+func NewWebhookServer(cfg *config.GithubConfig) (*WebhookServer, error) {
+	log := logrus.New()
+	log.SetFormatter(&logrus.JSONFormatter{})
+
+	// 秘密鍵の読み込み
+	privateKeyBytes, err := os.ReadFile(cfg.PrivateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read private key file: %v", err)
+	}
+
+	block, _ := pem.Decode(privateKeyBytes)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %v", err)
+	}
+
+	githubAuth := auth.NewGitHubAuth(cfg.AppID, privateKey)
+
+	ws := &WebhookServer{
+		log:           log,
+		auth:          githubAuth,
+		webhookSecret: cfg.WebhookSecret,
+		server: &http.Server{
+			Addr:              ":" + cfg.Port,
+			Handler:           nil,
+			ReadHeaderTimeout: 10 * time.Second,
+		},
+		agentManager: agent.NewManager(),
+	}
+
+	// GitHub App 情報の取得
+	jwt, err := githubAuth.GenerateJWT()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate JWT: %v", err)
+	}
+
+	ctx := context.Background()
+	client := github.NewTokenClient(ctx, jwt)
+	app, _, err := client.Apps.Get(ctx, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get app information: %v", err)
+	}
+	ws.appSlug = app.GetSlug()
+	log.Infof("GitHub App name (@%s) retrieved successfully", ws.appSlug)
+
+	// Create mux and set handlers
+	mux := http.NewServeMux()
+	mux.HandleFunc("/webhook", ws.handleWebhook)
+	ws.server.Handler = mux
+
+	return ws, nil
+}
+
+// Start はサーバーを起動します
+func (ws *WebhookServer) Start(ctx context.Context) error {
+	ws.log.Infof("Server is starting on port%s", ws.server.Addr)
+	if err := ws.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		return fmt.Errorf("could not listen on %s: %v", ws.server.Addr, err)
+	}
+	return nil
+}
+
+// Shutdown はサーバーを安全に停止します
+func (ws *WebhookServer) Shutdown(ctx context.Context) error {
+	ws.log.Info("Server is shutting down...")
+	return ws.server.Shutdown(ctx)
+}
+
+// isKommonCommand はコマンドが kommon コマンドかどうかを判定します
+func (ws *WebhookServer) isKommonCommand(text string) bool {
+	mentionText := "@" + ws.appSlug
+	return strings.Contains(text, "/kommon") || strings.Contains(text, mentionText)
+}
+
+// handleWebhook は webhook リクエストを処理します
+func (ws *WebhookServer) handleWebhook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	payload, err := github.ValidatePayload(r, []byte(ws.webhookSecret))
+	if err != nil {
+		ws.log.Errorf("Error validating webhook payload: %v", err)
+		http.Error(w, "Invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	event, err := github.ParseWebHook(github.WebHookType(r), payload)
+	if err != nil {
+		ws.log.Errorf("Error parsing webhook: %v", err)
+		http.Error(w, "Error parsing webhook", http.StatusBadRequest)
+		return
+	}
+
+	var installationID int64
+	switch e := event.(type) {
+	case *github.PushEvent:
+		installationID = e.GetInstallation().GetID()
+		ws.handlePushEvent(r.Context(), e, installationID)
+	case *github.PullRequestEvent:
+		installationID = e.GetInstallation().GetID()
+		ws.handlePullRequestEvent(r.Context(), e, installationID)
+	case *github.IssueCommentEvent:
+		installationID = e.GetInstallation().GetID()
+		ws.handleIssueCommentEvent(r.Context(), e, installationID)
+	default:
+		ws.log.WithFields(logrus.Fields{
+			"event_type": github.WebHookType(r),
+		}).Info("Received unhandled event type")
+	}
+
+	w.WriteHeader(http.StatusOK)
+}


### PR DESCRIPTION
## 変更内容

Issue #35 の対応として、cmd/github.go のコードをパッケージに分割しました。

### 主な変更点

1. コードの構造化
   - config パッケージ: 設定関連の構造体と初期化
   - auth パッケージ: JWT生成とGitHubクライアント生成
   - agent パッケージ: エージェント管理機能
   - server パッケージ: WebhookServer本体とイベントハンドラー

2. 改善点
   - エラーハンドリングの強化
   - ロギングの改善
   - コンテキストサポートの追加（graceful shutdown対応）
   - コードの可読性と保守性の向上
   - 依存関係の明確化

3. パッケージ構造
```
pkg/
  ├── config/
  │   └── config.go      # 設定構造体
  └── github/
      ├── auth/
      │   └── jwt.go     # 認証関連
      ├── agent/
      │   └── manager.go # エージェント管理
      └── server/
          ├── server.go  # WebhookServer
          └── handlers.go# イベントハンドラー
```

Closes #35